### PR TITLE
fix: Component refresh issue with reloading same route

### DIFF
--- a/src/app/routes/routes-routing.module.ts
+++ b/src/app/routes/routes-routing.module.ts
@@ -71,7 +71,12 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { useHash: environment.useHash })],
+  imports: [
+    RouterModule.forRoot(routes, {
+      useHash: environment.useHash,
+      onSameUrlNavigation: 'reload',
+    }),
+  ],
   exports: [RouterModule],
 })
 export class RouteRoutingModule {}

--- a/src/app/routes/simulations/components/simulation.component.ts
+++ b/src/app/routes/simulations/components/simulation.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, Output, OnInit, EventEmitter } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  OnInit,
+  EventEmitter,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 import {
   FormBuilder,
   FormControl,
@@ -29,7 +37,7 @@ import { SimulationService } from '../services/simulation.service';
     `,
   ],
 })
-export class SimulationComponent implements OnInit {
+export class SimulationComponent implements OnInit, OnChanges {
   @Input()
   simulation: Case | Job;
   @Output()
@@ -53,6 +61,16 @@ export class SimulationComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.initialiseState();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['simulation']) {
+      this.initialiseState();
+    }
+  }
+
+  initialiseState() {
     this.simulationService.updateName(this.simulation.name);
     this.simulationService.updateDescription(this.simulation.description);
 
@@ -121,7 +139,7 @@ export class SimulationComponent implements OnInit {
           .pipe(
             map(
               summaryList =>
-                summaryList.length == 0
+                summaryList.length === 0
                   ? null
                   : { error: true, duplicated: true },
             ),

--- a/src/app/routes/simulations/pages/configure-simulation.component.html
+++ b/src/app/routes/simulations/pages/configure-simulation.component.html
@@ -1,4 +1,3 @@
-<page-header></page-header>
 
 <nz-card>
   <sim-simulation [simulation]="job" (save)="onSave()" (run)="onRun()">

--- a/src/app/routes/simulations/pages/view-simulation.component.ts
+++ b/src/app/routes/simulations/pages/view-simulation.component.ts
@@ -9,9 +9,6 @@ import { SimulationService } from '../services/simulation.service';
 @Component({
   selector: 'app-view-simulation',
   template: `
-
-  <page-header></page-header>
-
   <nz-card *ngIf="outputs">
     <sim-downloads [outputs]="outputs"></sim-downloads>
   </nz-card>


### PR DESCRIPTION
Search bar was navigating to identical route but with new parameter, i.e. from

`http://localhost:8080/simulations/8c025ea1-bf8d-456f-abf6-f54dcccbdd3d`

to

`http://localhost:8080/simulations/63d099b3-2551-4412-913e-bef9ac7e4c95`

`SimulationComponent` was not being refreshed.

Solution is to create an `initialiseState()` method and call it via `ngOnChanges()`.

